### PR TITLE
그룹을 삭제하는 API 구현

### DIFF
--- a/src/main/java/com/capstone/moa/controller/GroupController.java
+++ b/src/main/java/com/capstone/moa/controller/GroupController.java
@@ -8,6 +8,8 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @AllArgsConstructor
 @RequestMapping("/api/group")
@@ -26,6 +28,13 @@ public class GroupController {
     @PutMapping("/{groupId}")
     public ResponseEntity<Void> modifyGroup(@PathVariable("groupId") Long groupId, @RequestBody ModifyGroupRequest request) {
         groupService.modifyGroup(groupId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "그룹 삭제")
+    @DeleteMapping("/{groupId}")
+    public ResponseEntity<Void> deletePost(@PathVariable("groupId") Long groupId, @RequestBody Map<String, String> email) {
+        groupService.deleteGroup(groupId, email.get("email"));
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/capstone/moa/service/GroupService.java
+++ b/src/main/java/com/capstone/moa/service/GroupService.java
@@ -54,4 +54,21 @@ public class GroupService {
 
         group.modify(request.getGroupName(), request.getInterest(), request.getIntroduce());
     }
+
+    @Transactional
+    public void deleteGroup(Long groupId, String email) {
+        Group group = groupRepository.findById(groupId)
+                .orElseThrow(() -> new IllegalArgumentException("Group not found"));
+
+        Member member = memberRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+
+        GroupMember groupMember = groupMemberRepository.findGroupMemberByGroupAndMember(group, member)
+                .orElseThrow(() -> new IllegalArgumentException("GroupMember not found"));
+
+        if (!groupMember.isGroupLeader()) {
+            throw new IllegalArgumentException("You are not the leader of this group");
+        }
+        groupRepository.delete(group);
+    }
 }


### PR DESCRIPTION
## 구현 기능
+ 그룹 삭제 기능 구현
+ 그룹 삭제 api 구현
+ 그룹의 leader가 아닌 경우 예외 반환

reslove : #42 

### 참고사항
Swagger에서 입력값 다음과 같이 수정해서 보낼 것.
```
{
    "email": "멤버이메일"
}
```
